### PR TITLE
Base64encoder unit tests

### DIFF
--- a/server/src/http_response.cpp
+++ b/server/src/http_response.cpp
@@ -12,18 +12,24 @@ using std::string;
 //Sort of based on solution from stack overflow, may need rewrite as it seems to have memory leak in valgrind
 void HTTP_Response::base64(unsigned char const* input, int length, char** buffer)
 {
-    BIO *bmem, *b64;
-    BUF_MEM *bptr;
-    b64 = BIO_new(BIO_f_base64());//This seems to be the source of some memory leaks that need to be resolved
+    if ( (input != NULL) && (input[0] == (char)0) ) {
+		*buffer = (char*)"";
+    }
+	else {
+		BIO *bmem, *b64;
+    	BUF_MEM *bptr;
+   		b64 = BIO_new(BIO_f_base64());//This seems to be the source of some memory leaks that need to be resolved
     bmem = BIO_new(BIO_s_mem());
-    b64 = BIO_push(b64, bmem);
-    BIO_write(b64, input, length);
-    BIO_flush(b64);
-    BIO_get_mem_ptr(b64, &bptr);
-    *buffer = new char[bptr->length];
-    memcpy(*buffer, bptr->data, bptr->length);
-    (*buffer)[bptr->length - 1] = 0;
-    BIO_free_all(b64); // This should stop the memory leak
+   		b64 = BIO_push(b64, bmem);
+    	BIO_write(b64, input, length);
+   	 	BIO_flush(b64);
+    	BIO_get_mem_ptr(b64, &bptr);
+    	*buffer = new char[bptr->length];
+   		memcpy(*buffer, bptr->data, bptr->length);
+    	(*buffer)[bptr->length - 1] = 0;
+    	BIO_free_all(b64); // This should stop the memory leak
+		
+    }
 }
 
 string HTTP_Response::generateWebSocketAcceptVal(const string& clientKey)

--- a/server/test/http_response_test.cpp
+++ b/server/test/http_response_test.cpp
@@ -2,6 +2,7 @@
 #include "gtest/gtest.h"
 #include "string"
 
+
 TEST(HTTP_Response, Base64_Basic) {
 	char* outBuffer = NULL;
 	unsigned char inputBinary[20] = "RWE%R$#FSDAADfFGDFQ";
@@ -9,3 +10,70 @@ TEST(HTTP_Response, Base64_Basic) {
 	string output(outBuffer);
 	EXPECT_EQ("UldFJVIkI0ZTREFBRGZGR0RGUQ==", output);
 }
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+* Tests as defined in RFC4648i sec. 10. Test Vectors: Base64 encoding
+* 	        https://tools.ietf.org/html/rfc4648#section-10
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector1) {
+	char* outBuffer = NULL;
+    const int strLen= 0;
+	unsigned char* inputBinary = (unsigned char*)"";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("", output);
+}
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector2) {
+	char* outBuffer = NULL;
+	const int strLen = 1;
+	unsigned char* inputBinary = (unsigned char*)"f";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zg==", output);
+}
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector3) {
+	char* outBuffer = NULL;
+    const int strLen = 2;
+	unsigned char* inputBinary = (unsigned char*)"fo";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zm8=", output);
+}
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector4) {
+	char* outBuffer = NULL;
+	const int strLen = 3;
+	unsigned char* inputBinary = (unsigned char*)"foo";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zm9v", output);
+}
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector5) {
+	char* outBuffer = NULL;
+	const int strLen = 4;
+	unsigned char* inputBinary = (unsigned char*)"foob";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zm9vYg==", output);
+}
+
+TEST(HTTP_Response, Base64_RFC4648_TestVector6) {
+	char* outBuffer = NULL;
+	const int strLen = 5;
+	unsigned char* inputBinary = (unsigned char*)"fooba";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zm9vYmE=", output);
+}
+TEST(HTTP_Response, Base64_RFC4648_TestVector7) {
+	char* outBuffer = NULL;
+	const int strLen = 6;
+	unsigned char* inputBinary = (unsigned char*)"foobar";
+	HTTP_Response::base64(inputBinary, strLen, &outBuffer);
+	string output(outBuffer);
+	EXPECT_EQ("Zm9vYmFy", output);
+}
+


### PR DESCRIPTION
- Added additional unit tests.
- Fixed base64encoder() to pass empty string condition.
- base64 Encoder passes all unit tests currently, but still has a memory leak. I am planning to address that next.
